### PR TITLE
Fix comparisons to singletons (use `is` or `is not` instead of `==` or `!=`)

### DIFF
--- a/gosecure_app.py
+++ b/gosecure_app.py
@@ -438,7 +438,7 @@ if __name__ == "__main__":
     app.secret_key=os.urandom(24)
     
     #if SSL key and certificate pair do not exist, create them.
-    if ((os.path.exists("ssl.key") and os.path.exists("ssl.crt")) != True):
+    if ((os.path.exists("ssl.key") and os.path.exists("ssl.crt")) is not True):
         os.system('openssl genrsa 2048 > ssl.key')
         os.system('openssl req -new -x509 -nodes -sha256 -days 1095 -subj "/C=US/O=goSecure/CN=goSecureClient" -key ssl.key > ssl.crt')
         os.system('sudo chown pi:pi ssl.crt ssl.key')

--- a/gosecure_app.py
+++ b/gosecure_app.py
@@ -162,14 +162,14 @@ def login():
                     vpn_configuration_status_bool = vpn_configuration_status()
 
                     #check to see if network is up. If not, redirect to network page
-                    if(internet_status_bool == False and vpn_configuration_status_bool == True):
+                    if(internet_status_bool is False and vpn_configuration_status_bool is True):
                         flash("Internet is not reachable.", "notice")
                         return redirect(url_for("wifi"))
                     #check to see if network and vpn are up. If not, redirect to initial setup page
-                    elif(internet_status_bool == False and vpn_status_bool == False):
+                    elif(internet_status_bool is False and vpn_status_bool is False):
                         return redirect(url_for("initial_setup"))
                     #check to see if vpn is up. If not, redirect to vpn page
-                    elif(vpn_status_bool == False):
+                    elif(vpn_status_bool is False):
                         flash("VPN is not established.", "notice")
                         return redirect(url_for("vpn_psk"))
                     else:
@@ -244,7 +244,7 @@ def initial_setup():
             psk = form.psk.data
             add_wifi(ssid, psk)
             
-            if(internet_status() == True):
+            if(internet_status() is True):
                 vpn_server = form.vpn_server.data
                 user_id = form.user_id.data
                 user_psk = form.user_psk.data
@@ -277,7 +277,7 @@ def wifi():
             add_wifi(ssid, psk)
             time.sleep(5)
             
-            if(internet_status() == True):
+            if(internet_status() is True):
                 restart_vpn()
                 time.sleep(5)
                 flash("Wifi settings saved! VPN Restarted!", "success")

--- a/scripts/rpi_network_conn.py
+++ b/scripts/rpi_network_conn.py
@@ -40,7 +40,7 @@ def add_wifi(wifi_ssid, wifi_key):
             else:
                 lines[x+1] = '    psk="%s"\n' % (wifi_key)
                 
-    if(wifi_exists != True):
+    if(wifi_exists is not True):
         lines.append('network={\n')
         lines.append('    ssid="%s"\n' % (wifi_ssid))
         if(wifi_key == "key_mgmt_none"):


### PR DESCRIPTION
> ["Comparisons to singletons like `None` should always be done with `is` or `is not` , never the equality operators."](https://www.python.org/dev/peps/pep-0008/#programming-recommendations)