### PR TITLE
[docs] Rename `file` to `f` to prevent shadowing built-in function

### DIFF
--- a/files/install_scripts/gosecure_client_install.py
+++ b/files/install_scripts/gosecure_client_install.py
@@ -80,8 +80,8 @@ def enable_hardware_random():
         call("sudo modprobe bcm2708-rng", shell=True)
         
         #call("sudo sh -c 'echo bcm2708-rng >> /etc/modules'")
-        with open("/etc/modules", "r+") as file:
-            for line in file:
+        with open("/etc/modules", "r+") as f:
+            for line in f:
                 if "bcm2708-rng" in line:
                     break
             else: # not found, we are at the eof
@@ -92,8 +92,8 @@ def enable_hardware_random():
         call("sudo modprobe bcm2835-rng", shell=True)
         
         #call("sudo sh -c 'echo bcm2835-rng >> /etc/modules'")
-        with open("/etc/modules", "r") as file:
-            for line in file:
+        with open("/etc/modules", "r") as f:
+            for line in f:
                 if "bcm2835-rng" in line:
                     break
             else: # not found, we are at the eof
@@ -187,8 +187,8 @@ def start_strongswan():
     call("sudo ipsec start", shell=True)
     
     #start strongSwan on boot
-    with open("/etc/network/if-pre-up.d/firewall", "r") as file:
-        for line in file:
+    with open("/etc/network/if-pre-up.d/firewall", "r") as f:
+        for line in f:
             if "sudo ipsec start" in line:
                 break
         else: # not found, we are at the eof
@@ -202,8 +202,8 @@ sudo sh -c \"echo 'ip route add table 220 192.168.50.0/24 dev eth0' >> /etc/rc.l
 sudo sh -c \"echo 'exit 0' >> /etc/rc.local\""""
     
     #add route on boot
-    with open("/etc/rc.local", "r+") as file:
-        for line in file:
+    with open("/etc/rc.local", "r+") as f:
+        for line in f:
             if "ip route add table 220 192.168.50.0/24 dev eth0" in line:
                 break
                 
@@ -260,8 +260,8 @@ log-dhcp
     
     #call("sudo sh -c 'echo \"192.168.50.1 setup\" >> /etc/hosts'", shell=True)
     #add domain name to local dns lookup file
-    with open("/etc/hosts", "r+") as file:
-        for line in file:
+    with open("/etc/hosts", "r+") as f:
+        for line in f:
             if "192.168.50.1 setup" in line:
                 break
         else: # not found, we are at the eof

--- a/files/install_scripts/gosecure_server_install_pi.py
+++ b/files/install_scripts/gosecure_server_install_pi.py
@@ -83,8 +83,8 @@ def enable_hardware_random():
         call("sudo modprobe bcm2708-rng", shell=True)
         
         #call("sudo sh -c 'echo bcm2708-rng >> /etc/modules'")
-        with open("/etc/modules", "r+") as file:
-            for line in file:
+        with open("/etc/modules", "r+") as f:
+            for line in f:
                 if "bcm2708-rng" in line:
                     break
             else: # not found, we are at the eof
@@ -95,8 +95,8 @@ def enable_hardware_random():
         call("sudo modprobe bcm2835-rng", shell=True)
         
         #call("sudo sh -c 'echo bcm2835-rng >> /etc/modules'")
-        with open("/etc/modules", "r") as file:
-            for line in file:
+        with open("/etc/modules", "r") as f:
+            for line in f:
                 if "bcm2835-rng" in line:
                     break
             else: # not found, we are at the eof
@@ -196,8 +196,8 @@ def start_strongswan():
     call("sudo ipsec start", shell=True)
     
     #start strongSwan on boot
-    with open("/etc/network/if-pre-up.d/firewall", "r") as file:
-        for line in file:
+    with open("/etc/network/if-pre-up.d/firewall", "r") as f:
+        for line in f:
             if "sudo ipsec start" in line:
                 break
         else: # not found, we are at the eof


### PR DESCRIPTION
[**file(name[, mode[, buffering]])**](https://docs.python.org/2.7/library/functions.html?highlight=file#file)

> Constructor function for the file type, described further in section File Objects. The constructor’s arguments are the same as those of the open() built-in function described below.
> 
> When opening a file, it’s preferable to use open() instead of invoking this constructor directly. file is more suited to type testing (for example, writing isinstance(f, file)).
> 
> New in version 2.2.