### PR TITLE
Reorder imports

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -1,5 +1,7 @@
-from wtforms import PasswordField, SelectField, SubmitField, StringField, validators
 from flask.ext.wtf import Form
+from wtforms import (
+    PasswordField, SelectField, SubmitField, StringField, validators)
+
 from scripts.rpi_network_conn import get_wifi_list
 
 

--- a/gosecure_app.py
+++ b/gosecure_app.py
@@ -1,17 +1,24 @@
 #!/usr/bin/env python
 
-from flask import Flask, render_template, request, Response, flash, redirect, url_for
-from functools import wraps
-import flask.ext.login as flask_login
 import hashlib
-import pickle
-from forms import loginForm, initialSetupForm, userForm, wifiForm, vpnPskForm, resetToDefaultForm, statusForm
-from scripts.rpi_network_conn import add_wifi, internet_status, reset_wifi
-from scripts.vpn_server_conn import set_vpn_params, reset_vpn_params, start_vpn, stop_vpn, restart_vpn, vpn_status, vpn_configuration_status
-from scripts.pi_mgmt import pi_reboot, pi_shutdown, start_ssh_service, update_client
-import time
 import os
-import json
+import pickle
+import time
+from functools import wraps
+
+import flask.ext.login as flask_login
+from flask import (
+    Flask, render_template, request, Response, flash, redirect, url_for)
+
+from forms import (
+    loginForm, initialSetupForm, userForm, wifiForm, vpnPskForm,
+    resetToDefaultForm, statusForm)
+from scripts.pi_mgmt import (
+    pi_reboot, pi_shutdown, start_ssh_service, update_client)
+from scripts.rpi_network_conn import add_wifi, internet_status, reset_wifi
+from scripts.vpn_server_conn import (
+    set_vpn_params, reset_vpn_params, start_vpn, stop_vpn, restart_vpn,
+    vpn_status, vpn_configuration_status)
 
 app = Flask(__name__)
 login_manager = flask_login.LoginManager()

--- a/scripts/pi_mgmt.py
+++ b/scripts/pi_mgmt.py
@@ -1,8 +1,8 @@
 import os
 import textwrap
+from subprocess import call
 
 import RPi.GPIO as GPIO
-from subprocess import call
 
 
 def pi_reboot():

--- a/scripts/rpi_network_conn.py
+++ b/scripts/rpi_network_conn.py
@@ -1,7 +1,8 @@
-from subprocess import CalledProcessError, check_output, Popen
-import wifi_captive_portal
-import urllib2
 import time
+from subprocess import CalledProcessError, check_output, Popen
+
+import urllib2
+import wifi_captive_portal
 
 
 def get_wifi_list():

--- a/scripts/vpn_server_conn.py
+++ b/scripts/vpn_server_conn.py
@@ -1,5 +1,6 @@
-from subprocess import CalledProcessError, check_output
 import time
+from subprocess import CalledProcessError, check_output
+
 from pi_mgmt import turn_on_led_green, turn_off_led_green
 
 


### PR DESCRIPTION
* https://pep8.org/#imports

    > Imports should be grouped in the following order:
    > 
    > 1. standard library imports
    > 2. related third party imports
    > 3. local application/library specific imports

