### PR TITLE
Simplify `return` statements, use `with` statements, bugfix

### DIFF
--- a/gosecure_app.py
+++ b/gosecure_app.py
@@ -22,7 +22,8 @@ login_manager.init_app(app)
 
 # users = {"admin":{"password":"2074ad04839ae517751e5948ae13f0e3c90d186c9c9bbd29c3c88b9c6000dba5", "salt":"uOMbInZTYYpiCGvEaH8Byw==\n"}}
 # default username=admin password=gosecure, user is prompted to change if default is being used.
-users = pickle.load(open("/home/pi/goSecure_Web_GUI/users_db.p", "rb"))
+with open("/home/pi/goSecure_Web_GUI/users_db.p", "rb") as fin:
+    users = pickle.load(fin)
 
 
 class User(flask_login.UserMixin):
@@ -101,10 +102,7 @@ def user_validate_credentials(username, password):
         stored_password = users[username]['password']
         stored_salt = users[username]['salt']
         userPasswordHash = hashlib.sha256(str(stored_salt) + password).hexdigest()
-        if stored_password == userPasswordHash:
-            return True
-        else:
-            return False
+        return stored_password == userPasswordHash
 
 
 # return True is password is changed successfully
@@ -120,7 +118,8 @@ def user_change_credentials(username, password, new_password):
             userPasswordHash = hashlib.sha256(str(userPasswordHashSalt) + new_password).hexdigest()
             users[username]["salt"] = userPasswordHashSalt
             users[username]["password"] = userPasswordHash
-            pickle.dump(users, open("/home/pi/goSecure_Web_GUI/users_db.p", "wb"))
+            with open("/home/pi/goSecure_Web_GUI/users_db.p", "wb") as fout:
+                pickle.dump(users, fout)
             return True
         else:
             return False
@@ -129,12 +128,9 @@ def user_change_credentials(username, password, new_password):
 # return True if credentials are reset
 # else return False
 def user_reset_credentials(username, password):
-    if user_change_credentials(username, password, "gosecure"):
-        return True
-    else:
-        return False
+    return user_change_credentials(username, password, "gosecure")
 
-    
+
 # Routes for web pages
 
 # 404 page

--- a/scripts/rpi_network_conn.py
+++ b/scripts/rpi_network_conn.py
@@ -90,7 +90,4 @@ def reset_wifi():
     except CalledProcessError as e:
         returncode = e.returncode
 
-    if returncode == 0:
-        return True
-    else:
-        return False
+    return returncode == 0

--- a/scripts/vpn_server_conn.py
+++ b/scripts/vpn_server_conn.py
@@ -19,9 +19,8 @@ def set_vpn_params(vpn_server, user_id, user_psk):
             fout.write(line)
 
     # save the username and secret to the ipsec.secrets file
-    secrets = open("/etc/ipsec.secrets", "w")
-    secrets.write("%s : PSK %s" % (user_id, user_psk))
-    secrets.close()
+    with open("/etc/ipsec.secrets", "w") as secrets:
+        secrets.write("%s : PSK %s" % (user_id, user_psk))
 
 
 def reset_vpn_params():
@@ -32,19 +31,15 @@ def reset_vpn_params():
 # add route for accessing local ip addresses on the LAN interface (prevents getting locked out from the goSecure Client web gui)
 def add_route():
     route_table_list = check_output(["ip", "route", "show", "table", "220"]).split("\n")
-    
+
     if "192.168.50.0/24 dev eth0  scope link" not in route_table_list:
         try:
             check_output(["sudo", "ip", "route", "add", "table", "220", "192.168.50.0/24", "dev", "eth0"])
             returncode = 0
         except CalledProcessError as e:
-                returncode = e.returncode
-                
-        if returncode == 0:
-                return True
-        else:
-            return False
-        
+            returncode = e.returncode
+
+        return returncode == 0
     else:
         return True
 
@@ -57,13 +52,10 @@ def start_vpn():
     except CalledProcessError as e:
         returncode = e.returncode
         
-    if returncode == 0:
-        if vpn_status():
-            if add_route:
-                time.sleep(3)
-                turn_on_led_green()
-                return True
-
+    if returncode == 0 and vpn_status() and add_route():
+        time.sleep(3)
+        turn_on_led_green()
+        return True
     else:
         return False
 
@@ -76,10 +68,7 @@ def stop_vpn():
     except CalledProcessError as e:
         returncode = e.returncode
     
-    if returncode == 0:
-        return True
-    else:
-        return False
+    return returncode == 0
 
 
 def restart_vpn():
@@ -92,12 +81,10 @@ def restart_vpn():
     except CalledProcessError as e:
         returncode = e.returncode
     
-    if returncode == 0:
-        if vpn_status():
-            if add_route():
-                time.sleep(3)
-                turn_on_led_green()
-                return True
+    if returncode == 0 and vpn_status() and add_route():
+        time.sleep(3)
+        turn_on_led_green()
+        return True
     else:
         return False
 
@@ -141,7 +128,4 @@ def vpn_configuration_status():
         if (lines[0].strip())[0:49] != "<unique_id_of_client> : PSK <password_for_client>":
             vpn_psk = 1
 
-    if leftid_set == 1 and right_set == 1 and vpn_psk == 1:
-        return True
-    else:
-        return False
+    return leftid_set == 1 and right_set == 1 and vpn_psk == 1

--- a/scripts/wifi_captive_portal.py
+++ b/scripts/wifi_captive_portal.py
@@ -14,11 +14,7 @@ def captive_portal(wifi_ssid, cp_username, cp_password):
 
     br.addheaders = [('User-agent', 'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.1) Gecko/2008071615 Fedora/3.0.1-1.fc9 Firefox/3.0.1')]
     
-    if wifi_ssid == "Google Starbucks":
-        if cp_starbucks(br):
-            return True
-    else:
-        return False
+    return wifi_ssid == "Google Starbucks" and cp_starbucks(br)
 
 
 def cp_starbucks(br):


### PR DESCRIPTION
* Simplified a number of `return` statements
* Used `with` statement context managers for IO (to ensure closing in case of error and to stay consistent with the rest of the project)
* Fixed a minor bug while simplifying a `return` statement
    The `add_route` function was not being called inside of `scripts/vpn_server_conn.start_vpn`.
    
    ```python
    if returncode == 0:
        if vpn_status():
            if add_route:
                time.sleep(3)
                turn_on_led_green()
                return True
    
    ```
    
    `if add_route:` always evaluates to `True` since the function is not being called.
    
    ```python
    >>> def add_route():
    ...     return False
    ... 
    >>> bool(add_route)
    True
    >>> bool(add_route())
    False
    ```
    This nested `if` statement can be simplified (while keeping the exact same functionality) since [`and` is a short-circuit operator](https://docs.python.org/3/library/stdtypes.html#boolean-operations-and-or-not).
    
    ```python
    # Solution
    if returncode == 0 and vpn_status() and add_route():
        time.sleep(3)
        turn_on_led_green()
        return True
    
    ```
