### PR TITLE
`vpn_server_conn.py` updates

### DIFF
--- a/scripts/vpn_server_conn.py
+++ b/scripts/vpn_server_conn.py
@@ -109,7 +109,7 @@ def vpn_configuration_status():
     with open("/etc/ipsec.conf") as fin:
         lines = fin.readlines()
 
-    for i, line in enumerate(lines):
+    for line in lines:
         current_line = line.strip()
         if (current_line.startswith("leftid=") and
                 not current_line.startswith("leftid=<unique_id_of_client>")):

--- a/scripts/vpn_server_conn.py
+++ b/scripts/vpn_server_conn.py
@@ -9,15 +9,15 @@ def set_vpn_params(vpn_server, user_id, user_psk):
     with open("/etc/ipsec.conf") as fin:
         lines = fin.readlines()
 
-    for x in range(0, len(lines)):
-        if (lines[x].strip())[0:7] == "leftid=":
-            lines[x] = "        leftid=%s       #unique id of client\n" % user_id
-        if (lines[x].strip())[0:6] == "right=":
-            lines[x] = "        right=%s       #strongSwan server external IP\n" % vpn_server
+    for i, line in enumerate(lines):
+        current_line = line.strip()
+        if current_line.startswith("leftid="):
+            lines[i] = "        leftid=%s       # unique id of client\n" % user_id
+        elif current_line.startswith("right="):
+            lines[i] = "        right=%s       # strongSwan server external IP\n" % vpn_server
 
     with open("/etc/ipsec.conf", "w") as fout:
-        for line in lines:
-            fout.write(line)
+        fout.writelines(lines)
 
     # save the username and secret to the ipsec.secrets file
     with open("/etc/ipsec.secrets", "w") as secrets:
@@ -25,35 +25,36 @@ def set_vpn_params(vpn_server, user_id, user_psk):
 
 
 def reset_vpn_params():
-    set_vpn_params("<eth0_ip_of_server>", "<unique_id_of_client>", "<password_for_client>")
+    set_vpn_params("<eth0_ip_of_server>",
+                   "<unique_id_of_client>",
+                   "<password_for_client>")
     stop_vpn()
 
 
-# add route for accessing local ip addresses on the LAN interface (prevents getting locked out from the goSecure Client web gui)
 def add_route():
+    """ Add route for accessing local ip addresses on the LAN interface
+    (prevents getting locked out from the goSecure Client web gui)
+    """
+
     route_table_list = check_output(["ip", "route", "show", "table", "220"]).split("\n")
 
     if "192.168.50.0/24 dev eth0  scope link" not in route_table_list:
         try:
             check_output(["sudo", "ip", "route", "add", "table", "220", "192.168.50.0/24", "dev", "eth0"])
-            returncode = 0
-        except CalledProcessError as e:
-            returncode = e.returncode
-
-        return returncode == 0
-    else:
-        return True
+        except CalledProcessError:
+            return False
+    return True
 
 
 def start_vpn():
     try:
         check_output(["sudo", "ipsec", "start"])
-        returncode = 0
+    except CalledProcessError:
+        return False
+    else:
         time.sleep(10)
-    except CalledProcessError as e:
-        returncode = e.returncode
-        
-    if returncode == 0 and vpn_status() and add_route():
+
+    if vpn_status() and add_route():
         time.sleep(3)
         turn_on_led_green()
         return True
@@ -64,25 +65,24 @@ def start_vpn():
 def stop_vpn():
     try:
         check_output(["sudo", "ipsec", "stop"])
-        returncode = 0
+    except CalledProcessError:
+        return False
+    else:
         turn_off_led_green()
-    except CalledProcessError as e:
-        returncode = e.returncode
-    
-    return returncode == 0
+        return True
 
 
 def restart_vpn():
     turn_off_led_green()
-    
+
     try:
         check_output(["sudo", "ipsec", "restart"])
-        returncode = 0
+    except CalledProcessError:
+        return False
+    else:
         time.sleep(10)
-    except CalledProcessError as e:
-        returncode = e.returncode
-    
-    if returncode == 0 and vpn_status() and add_route():
+
+    if vpn_status() and add_route():
         time.sleep(3)
         turn_on_led_green()
         return True
@@ -92,17 +92,12 @@ def restart_vpn():
 
 def vpn_status():
     try:
-        vpn_status = (check_output(["sudo", "ipsec", "status"])).split("\n")
-        returncode = 0
-    except CalledProcessError as e:
-        returncode = e.returncode
-    
-    # if ipsec status command ran successfully, check if tunnel is established
-    if returncode == 0:
-        if (vpn_status[1].strip())[9:20] == "ESTABLISHED":
-            return True
-
-    return False
+        vpn_status_info = check_output(["sudo", "ipsec", "status"]).split("\n")
+    except CalledProcessError:
+        return False
+    else:
+        # ipsec status command ran successfully, check if tunnel is established
+        return vpn_status_info[1].strip()[9:20] == "ESTABLISHED"
 
 
 def vpn_configuration_status():
@@ -114,19 +109,21 @@ def vpn_configuration_status():
     with open("/etc/ipsec.conf") as fin:
         lines = fin.readlines()
 
-    for x in range(0, len(lines)):
-        if (lines[x].strip())[0:7] == "leftid=":
-            if (lines[x].strip())[7:28] != "<unique_id_of_client>":
-                leftid_set = 1
-        if (lines[x].strip())[0:6] == "right=":
-            if (lines[x].strip())[6:25] != "<eth0_ip_of_server>":
-                right_set = 1
+    for i, line in enumerate(lines):
+        current_line = line.strip()
+        if (current_line.startswith("leftid=") and
+                not current_line.startswith("leftid=<unique_id_of_client>")):
+            leftid_set = 1
+        elif (current_line.startswith("right=") and
+              not current_line.startswith("right=<eth0_ip_of_server>")):
+            right_set = 1
 
-    # check to see if the username and secret are set in the ipsec.secrets file
+    # check if the username and secret are set in the ipsec.secrets file
     with open("/etc/ipsec.secrets") as fin:
-        lines = fin.readlines()
+        first_line = next(fin).strip()
 
-        if (lines[0].strip())[0:49] != "<unique_id_of_client> : PSK <password_for_client>":
-            vpn_psk = 1
+    if not first_line.startswith(
+            "<unique_id_of_client> : PSK <password_for_client>"):
+        vpn_psk = 1
 
     return leftid_set == 1 and right_set == 1 and vpn_psk == 1


### PR DESCRIPTION
`set_vpn_params`

* Use `enumerate` to iterate over `lines` (since both index and value are needed)
* Use `str.startswith` doesn't create an extra string when using a string slice, `[0:7] or [0:6]`
* Use `file.writelines` instead of looping over `lines` and using `file.write` for each line

`reset_vpn_params`

* Shorten the overall line length of `set_vpn_params(...)` by adding newlines after each arg

`add_route`

* Move comment inside as a docstring
* Simplify `try/except` code
    
    > [`CalledProcessError`: Exception raised when a process run by check_call() or check_output() returns a non-zero exit status.](https://docs.python.org/2/library/subprocess.html#subprocess.CalledProcessError)
    
    So, if that exception was raised it could immediately return `False` without having to check if it was `0` (since it won't ever be).

    One option is to then add `else` to the `try/except` block and return `True`. It seemed superfluous since the only other return value underneath the enclosing `if` statement was `True`. For that reason, I chose to skip the `else` and let it fall through to a single `return True` at the bottom of the function.

`start_vpn`

* Simplify `try/except`

    `returncode` was only being used to check if it was `0`. This allowed the same immediate `return False` if `CalledProcessError` was raised. Also, one less check in the bottom `if` statement as well.

`stop_vpn`

* Simplify `try/except`

    `returncode` was only being used to check if it was `0`. This allowed the same immediate `return False` if `CalledProcessError` was raised. Using `else` helps keep the code clean and less error-prone.

    > [The use of the `else` clause is better than adding additional code to the `try` clause because it avoids accidentally catching an exception that wasn’t raised by the code being protected by the `try` ... `except` statement.](https://docs.python.org/2/tutorial/errors.html#handling-exceptions)

`restart_vpn`

* Simplify `try/except`

    `returncode` was only being used to check if it was `0`. This allowed the same immediate `return False` if `CalledProcessError` was raised. Also, one less check in the bottom `if` statement as well.

`vpn_status`

* Simplified `try/except`
    
    `returncode` was only being used to check if it was `0`. This allowed the same immediate `return False` if `CalledProcessError` was raised. Using `else` helps keep the code clean and less error-prone.

`vpn_configuration_status`

* Use a regular `for` loop to iterate over `lines`
* Use `str.startswith` doesn't create an extra string when using a string slice, `[0:7] or [0:6] or [7:28] or [6:25]`
* Use `next(fin)` instead of `fin.readlines` since only the first line was being used below
