### PR TITLE
`rpi_network_conn.py` updates

### DIFF
--- a/scripts/rpi_network_conn.py
+++ b/scripts/rpi_network_conn.py
@@ -1,94 +1,100 @@
+import textwrap
 import time
+import urllib2
 from subprocess import CalledProcessError, check_output, Popen
 
-import urllib2
 import wifi_captive_portal
 
 
 def get_wifi_list():
+    # check wlan status, return [] if no wifi available
     try:
-        wlan_status = check_output(["sudo", "ifup", "wlan0"])
-        returncode = 0
-    except CalledProcessError as e:
-        returncode = e.returncode
+        check_output(["sudo", "ifup", "wlan0"])
+    except CalledProcessError:
+        return []
 
+    # check for wifi access points in range, return [] if none available
     try:
-        iw_list = (check_output(["sudo", "iwlist", "wlan0", "scan"])).split("\n")
-    except CalledProcessError as e:
-        iw_list = []
+        iw_list = check_output(["sudo", "iwlist", "wlan0", "scan"]).split("\n")
+    except CalledProcessError:
+        return []
 
     # contains a tuple of the (ESSID, Encryption key)
     wifi_list = []
 
-    for x in range(0, len(iw_list)):
-        if (iw_list[x].strip())[0:5] == "ESSID":
-            if (iw_list[x].strip())[7:-1] != "" and (not (iw_list[x].strip())[7:-1].startswith("\\")):
-                wifi_list.append((((iw_list[x].strip())[7:-1] + "-" + ((iw_list[x-1].strip())[15:])), (iw_list[x].strip())[7:-1]))
+    for i, interface_info in enumerate(iw_list):
+        current = interface_info.strip()
+        if current.startswith("ESSID"):
+            end = current[7:-1]
+            if end and (not end.startswith("\\")):
+                wifi_list.append(
+                    ('%s-%s' % (end, iw_list[i - 1].strip()[15:]), end))
 
-    return sorted(list(set(wifi_list)), key=lambda wifilist: wifilist[0])
+    return sorted(set(wifi_list), key=lambda wifilist: wifilist[0])
 
 
 def add_wifi(wifi_ssid, wifi_key):
+    ssid = 'ssid="%s"' % wifi_ssid
+
+    if wifi_key == "key_mgmt_none":
+        wifi_key_info = "    key_mgmt=NONE\n"
+    else:
+        wifi_key_info = '    psk="%s"\n' % wifi_key
+
     with open("/etc/wpa_supplicant/wpa_supplicant.conf") as wpa_supplicant:
         lines = wpa_supplicant.readlines()
-    
+
     wifi_exists = False
-    for x in range(0, len(lines)):
-        #if SSID is already in file
-        if (lines[x].strip()) == 'ssid="' + str(wifi_ssid) + '"':
+    for i in xrange(len(lines)):
+        # if SSID is already in file
+        if lines[i].strip() == ssid:
             wifi_exists = True
-            lines[x] = '    ssid="%s"\n' % wifi_ssid
-            if wifi_key == "key_mgmt_none":
-                lines[x+1] = '    key_mgmt=NONE\n'
-            else:
-                lines[x+1] = '    psk="%s"\n' % wifi_key
+            lines[i] = "    %s\n" % ssid
+            lines[i + 1] = wifi_key_info
 
-    if wifi_exists is not True:
-
-        lines.append('network={\n')
-        lines.append('    ssid="%s"\n' % wifi_ssid)
-        if wifi_key == "key_mgmt_none":
-            lines.append('    key_mgmt=NONE\n')
-        else:
-            lines.append('    psk="%s"\n' % wifi_key)
-        lines.append('}\n')
+    if not wifi_exists:
+        lines.append(textwrap.dedent("""\
+            network={
+                %s
+                %s
+            }
+            """ % (ssid, wifi_key_info)))
 
     with open("/etc/wpa_supplicant/wpa_supplicant.conf", "w") as fout:
-        for line in lines:
-            fout.write(line)
-    
+        fout.writelines(lines)
+
     process = Popen(["sudo", "ifdown", "wlan0"])
     process.wait()
     process = Popen(["sudo", "ifup", "wlan0"])
     process.wait()
-    
+
     time.sleep(15)
-    
+
     if not internet_status():
         wifi_captive_portal.captive_portal(wifi_ssid, "", "")
 
 
 def internet_status():
     try:
-        response = urllib2.urlopen("https://aws.amazon.com", timeout=1)
+        urllib2.urlopen("https://aws.amazon.com", timeout=1)
+    except urllib2.URLError:
+        return False
+    else:
         return True
-    except urllib2.URLError as err:
-        pass
-    return False
 
 
 def reset_wifi():
-    lines = ["country=US\n",
-             "ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev\n",
-             "update_config=1\n"]
+    lines = textwrap.dedent("""\
+        country=US
+        ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
+        update_config=1
+        """)
     with open("/etc/wpa_supplicant/wpa_supplicant.conf", "w") as fout:
-        for line in lines:
-            fout.write(line)
-    
-    try:
-        vpn_status = (check_output(["sudo", "ifdown", "wlan0"]))
-        returncode = 0
-    except CalledProcessError as e:
-        returncode = e.returncode
+        fout.write(lines)
 
-    return returncode == 0
+    try:
+        check_output(["sudo", "ifdown", "wlan0"])
+    except CalledProcessError:
+        return False
+    else:
+        return True


### PR DESCRIPTION
* Reorder imports as suggested by PEP8

`get_wifi_list`

* Remove assignment to `wlan_status` since it wasn't being used for anything
* Remove `returncode` since it wasn't being used for anything
* Return `[]` if `sudo ifup wlan0` fails. It would seem if the wifi is down, the next call to check nearby wifi access points will likely fail as well.
* Remove redundant parentheses
* Return `[]` if `sudo iwlist wlan0 scan` fails. It doesn't seem to make sense to try to iterate an empty list, create a set out of an empty list and then try to sort an empty set.
* `range` loop replaced with `enumerate` since both the index and value are needed
* On the worst case, `iw_list[x].strip()` was being created 5 times. Also, each instance was then creating another slice. To cut down on unnecessary copies, the `current` variable saves the stripped current line.
* Using `str.startswith` doesn't create unnecessary copies either
* `end` variable was created to reuse the same slice 4 times
* Remove `list(...)` inside of `sorted(...)` since it was creating an unnecessary list instead of just creating the sorted list directly from `set(wifi_list)`

`add_wifi`

* Create `ssid` once instead of creating it via concatenation on each iteration of the loop
* Create `wifi_key_info` once instead of (potentially) multiple times inside the loop (also, `if wifi_exists is False`)
* Use `xrange` instead of `range`
* Remove redundant parentheses
* Simplify network string creation using a multi-line string and `textwrap.dedent` to keep proper indentation
* Use `file.writelines` instead of `file.write` for each separate line

`internet_status`

* Remove assignment to `response` since it wasn't being used for anything
* `return False` immediately if `urllib2.URLError` is raised
* Move `return True` to the `else` statement (for readability and to stay consistent with other project files)

`reset_wifi`

* Use a multi-line string and `textwrap.dedent` to create `lines`
* Remove assignment to `vpn_status` since it wasn't being used for anything
* Remove `returncode` since it wasn't being used for anything
* `return False` immediately if `CalledProcessError` is raised
* `return True` in the `else` since `CalledProcessError` is only raised for a non-zero exit code (no need to check `returncode == 0`)
